### PR TITLE
Add setting to change indicator padding

### DIFF
--- a/src/dotspaces.js
+++ b/src/dotspaces.js
@@ -29,9 +29,11 @@ class DotIndicator extends St.Bin {
         // Set the icon
         this._icon = null;
 
-        // Add style classes
+        // Add styles
         this.add_style_class_name("panel-button");
         this.add_style_class_name("dotspaces-indicator");
+        this.set_style(`padding-left: ${this._settings.wsIndicatorPadding}px;`
+            + `padding-right: ${this._settings.wsIndicatorPadding}px;`);
 
         // Signals
         this.connect('destroy', () => {
@@ -118,6 +120,7 @@ var DotspaceContainer = class DotspaceContainer extends St.BoxLayout {
         // Handle setting events
         this._dotspaceSettings.onChangedIgnoreInactiveOccupiedWorkspaces(this._RebuildDots.bind(this));
         this._dotspaceSettings.onChangedHideDotsOnSingle(this._RebuildDots.bind(this));
+        this._dotspaceSettings.onChangedWsIndicatorPadding(this._RebuildDots.bind(this));
         this._mutterSettings.onChangedDynamicWorkspaces(this._RebuildDots.bind(this));
         
         // Handle workspace events

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -35,6 +35,16 @@ function fillPreferencesWindow(window) {
     // Bind settings to switches
     DotspaceSettings.getKeys().forEach(key => {
         const widget = builder.get_object(key.replaceAll('-', '_'));
-        dotspaceSettings.bind(key, widget, 'active', Gio.SettingsBindFlags.DEFAULT);
+        switch (key) {
+            case DotspaceSettings.WS_INDICATOR_PADDING:
+                widget.set_value(dotspaceSettings.get_int(key));
+                widget.connect('value-changed', (w) => {
+                    dotspaceSettings.set_int(key, w.get_value());
+                });
+                break;
+            default:
+                dotspaceSettings.bind(key, widget, 'active', Gio.SettingsBindFlags.DEFAULT);
+                break;
+        }
     });
 }

--- a/src/schemas/org.gnome.shell.extensions.dotspaces.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.dotspaces.gschema.xml
@@ -16,5 +16,8 @@
         <key name="hide-dots-on-single" type="b">
             <default>false</default>
         </key>
+        <key name="ws-indicator-padding" type="i">
+            <default>6</default>
+        </key>
     </schema>
 </schemalist>

--- a/src/settings.js
+++ b/src/settings.js
@@ -22,7 +22,15 @@ var Settings = class Settings {
     setBoolean(key, value) { 
         this._schema.set_boolean(key, value); 
     }
-}
+
+    getInt(key) {
+        return this._schema.get_int(key);
+    }
+
+    setInt(key, value) {
+        this._schema.set_int(key, value);
+    }
+};
 
 /**
  * Handles settings for this extension.
@@ -33,7 +41,8 @@ var DotspaceSettings = class DotspaceSettings extends Settings {
     static PANEL_SCROLL = "panel-scroll";
     static WRAP_WORKSPACES = "wrap-workspaces";
     static HIDE_DOTS_ON_SINGLE = "hide-dots-on-single";
-    
+    static WS_INDICATOR_PADDING = "ws-indicator-padding";
+
     static getNewSchema() {
         const extensionUtils = imports.misc.extensionUtils;
         return extensionUtils.getSettings(extensionUtils.getCurrentExtension().metadata['settings-schema']);
@@ -45,7 +54,8 @@ var DotspaceSettings = class DotspaceSettings extends Settings {
             this.KEEP_ACTIVITIES,
             this.PANEL_SCROLL,
             this.WRAP_WORKSPACES,
-            this.HIDE_DOTS_ON_SINGLE
+            this.HIDE_DOTS_ON_SINGLE,
+            this.WS_INDICATOR_PADDING,
         ];
     }
     
@@ -73,6 +83,10 @@ var DotspaceSettings = class DotspaceSettings extends Settings {
         return this.getBoolean(DotspaceSettings.HIDE_DOTS_ON_SINGLE);
     }
 
+    get wsIndicatorPadding() {
+        return this.getInt(DotspaceSettings.WS_INDICATOR_PADDING);
+    }
+
     onChangedIgnoreInactiveOccupiedWorkspaces(func) {
         this.onChanged(DotspaceSettings.IGNORE_INACTIVE_OCCUPIED_WORKSPACES, func);
     }
@@ -88,7 +102,11 @@ var DotspaceSettings = class DotspaceSettings extends Settings {
     onChangedHideDotsOnSingle(func) {
         this.onChanged(DotspaceSettings.HIDE_DOTS_ON_SINGLE, func);
     }
-}
+
+    onChangedWsIndicatorPadding(func) {
+        this.onChanged(DotspaceSettings.WS_INDICATOR_PADDING, func);
+    }
+};
 
 /**
  * Handles settings for Mutter.

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -1,8 +1,3 @@
-.dotspaces-indicator {
-  padding-left: 6px;
-  padding-right: 6px;
-}
-
 .dotspaces-indicator:active {
   box-shadow: none;
 }

--- a/src/ui/main.xml
+++ b/src/ui/main.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
+    <object class="GtkAdjustment" id="ws_indicator_padding_adjustment">
+        <property name="lower">0</property>
+        <property name="upper">30</property>
+        <property name="step_increment">1</property>
+    </object>
+
     <object class="AdwPreferencesPage" id="general">
         <child>
             <object class="AdwPreferencesGroup">
@@ -59,6 +65,18 @@
                         <child>
                             <object class="GtkSwitch" id="hide_dots_on_single">
                                 <property name="valign">center</property>
+                            </object>
+                        </child>
+                    </object>
+                </child>
+                <child>
+                    <object class="AdwActionRow">
+                        <property name="title">Workspace indicator padding</property>
+                        <property name="subtitle">Distance between workspace indicators</property>
+                        <child>
+                            <object class="GtkSpinButton" id="ws_indicator_padding">
+                                <property name="valign">center</property>
+                                <property name="adjustment">ws_indicator_padding_adjustment</property>
                             </object>
                         </child>
                     </object>


### PR DESCRIPTION
Now we can change the distance between workspace indicators. Closes [issue #2](https://github.com/CharlieQLe/gnome-extension-dotspaces/issues/2).